### PR TITLE
Improve python3 compatibility

### DIFF
--- a/pySMART/__init__.py
+++ b/pySMART/__init__.py
@@ -102,5 +102,5 @@ from .attribute import Attribute
 from .device import Device
 from .device_list import DeviceList
 from .test_entry import Test_Entry
-import utils
+from . import utils
 __version__ = '0.3.5'

--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -413,12 +413,14 @@ class Device(object):
                     if not self.assessment == 'FAIL':
                         self.assessment = 'WARN'
 
+    @cmd_convert_bytes
     def _cmd_all_with_type(self):
         cmd = Popen('/usr/bin/env smartctl -d {0} -a {1}'.format(
             self._get_device_type(), self.path), shell=True,
             stdout=PIPE, stderr=PIPE)
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_all(self):
         cmd = Popen(
             '/usr/bin/env smartctl -a {0}'.format(self.path),
@@ -428,6 +430,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_power_on_scan(self):
         cmd = Popen(
             'smartctl -d scsi -l background {0}'.format(self.path),
@@ -437,6 +440,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_run_test(self, test_type):
         cmd = Popen(
             'smartctl -d {0} -t {1} {2}'.format(
@@ -450,6 +454,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_get_capabilities(self):
         cmd = Popen(
             'smartctl -d {0} -c {1}'.format(
@@ -462,6 +467,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_sataphy(self, test):
         cmd = Popen(
             'smartctl -d {0} -l sataphy {1}'.format(
@@ -473,6 +479,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_sasphy(self):
         cmd = Popen(
             'smartctl -d scsi -l sasphy {0}'.format(self.path),
@@ -482,6 +489,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_scsi_all(self):
         cmd = Popen(
             'smartctl -d scsi -a {0}'.format(self.path),
@@ -491,6 +499,7 @@ class Device(object):
         )
         return cmd.communicate()
 
+    @cmd_convert_bytes
     def _cmd_scan_open(self, grep_cmd_name):
         cmd = Popen(
             '/usr/bin/env smartctl --scan-open | {0} "{1}"'.format(


### PR DESCRIPTION
This makes pysmart run fine with python3, where Popen returns bytes not str.