### PR TITLE
Update utils.py

### DIFF
--- a/pySMART/utils.py
+++ b/pySMART/utils.py
@@ -149,7 +149,7 @@ def verify_smartctl():
             "Required package 'smartmontools' is not installed, or 'smartctl'\n"
             "component is not on the system path. Please install and try again.")
     else:
-        for line in _stdout.split('\n'):
+        for line in _stdout.decode().strip('\n').split('\n'):
             if 'release' in line:
                 _ma, _mi = line.strip().split(' ')[2].split('.')
                 if (int(_ma) < _req_ma or


### PR DESCRIPTION
Modif done because of this bug : 

```
abyss ~ # python
Python 3.6.4 (default, Feb  6 2018, 18:33:58)
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pySMART import DeviceList
>>> devlist = DeviceList()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/.local/lib64/python3.6/site-packages/pySMART/device_list.py", line 52, in __init__
    self._initialize()
  File "/root/.local/lib64/python3.6/site-packages/pySMART/device_list.py", line 98, in _initialize
    for line in _stdout.split('\n'):
TypeError: a bytes-like object is required, not 'str'
```