### PR TITLE
Add "supports_self_test_log" attribute 

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -104,6 +104,11 @@ class Device(object):
         for this device, as provided by smartctl. Indexed by attribute #,
         values are set to 'None' for attributes not suported by this device.
         """
+        self.supports_self_test_log = None
+        """
+        **(bool):** True, if Self-test logging is supported
+        False otherwise.
+        """
         self.tests = []
         """
         **(list of `Log_Entry`):** Contains the complete SMART self-test log
@@ -681,6 +686,11 @@ class Device(object):
                     self.assessment = 'FAIL'
                     parse_ascq = True  # Set flag to capture status message
                     message = line.split(':')[1].lstrip().rstrip()
+            if 'self' and 'test' and 'log' and not 'selective' in line.lower():
+                if 'revision number' in line:
+                    self.supports_self_test_log = True
+                elif 'not' and 'support' in line:
+                    self.supports_self_test_log = False
             # SMART Attribute table parsing
             if '0x0' in line and '_' in line:
                 # Replace multiple space separators with a single space, then


### PR DESCRIPTION
This commit adds the device attribute 'supports_self_test_log' to be able to distinguish an empty 'tests' list between 'a test has never run' or 'I am just not able to list recent tests'.

Parsing is done on lower string, since I observed the following relevant strings with different devices (list may not be exhaustive):

> SMART Selective self-test log data structure revision number 1
> Device does not support Self Test logging
> SMART Self-test Log not supported

There is also a different log for selective self-tests. That may also be added, but since they are not registered otherwise in current pySMART and I do not have any use for I left it out for now.